### PR TITLE
enhance Login

### DIFF
--- a/Login/function.tsx
+++ b/Login/function.tsx
@@ -5,6 +5,21 @@ import * as Keychain from 'react-native-keychain';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 
+export const checkFastLoginSelection = async () => { //should use saveData to set 'FastLogin' to 'true'
+    try {
+        const value = await AsyncStorage.getItem('FastLogin');
+        if (value) {
+            return (value);
+        }
+        else {
+            return ('false');
+        }
+    } catch (e) {
+        console.log("error", e);
+    }
+};
+
+
 export const showToast = (text1: string, text2: string, type = 'success') => {
     Toast.show({
         type: type,

--- a/Login/index.tsx
+++ b/Login/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from "react";
 import { View, Text, TextInput, Button, Pressable, StyleSheet } from 'react-native';
 import { NavigationContainer, getFocusedRouteNameFromRoute, DefaultTheme, DarkTheme } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
-import { submitLogin, submitRegister, showToast, saveCredentials, getCredentialsFromKeychain, saveData, getDataJSON } from "./function";
-
+import { submitLogin, submitRegister, showToast, saveCredentials, getCredentialsFromKeychain, saveData, getDataJSON, checkFastLoginSelection } from "./function";
+import Icon from 'react-native-vector-icons/Ionicons';
 // //2. 處理後端溝通 測試範例:貼function response data中
 // const loginReturndata = {
 //     state: "success",
@@ -31,42 +31,79 @@ const LoginAssociate = (props: any) => {
     const [email, setEmail] = useState('');
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
+    const [passwordCheck, setPasswordCheck] = useState('');
 
     const [emailL, setEmailL] = useState('');
     const [passwordL, setPasswordL] = useState('');
     //check whether already login before "登入資訊是否儲存"
 
+    const [fast, setFast] = useState(false);
+    const [waiting, setWaiting] = useState(true); //等待模式 (等server 反應)
     useEffect(() => {
         const logindata = getCredentialsFromKeychain();
         async function FastLogin() {
+            const FLSelect = await checkFastLoginSelection();
+            if (FLSelect === 'false') {
+                setFast(false);
+                setWaiting(false);
+                return;
+            } else {
+                setFast(true);
+            }
+
             const logdata = await logindata;
             if (logdata) {
-                props.navigation.push('tab', { From: 'login' });
-                // submitLogin(logdata.email, logdata.password, (data: any) => {
-                //     // success = save the logindata that response on clint device also their password
-                //     const usernameLS = data.username;
-                //     const headImgLS = data.headImg;
-                //     const UserData = JSON.stringify({ email:logdata.email, usernameLS, headImgLS });
-                //     saveData('UserData', UserData);
-                //     props.navigation.push('tab', { From: 'login' });
-                // }, (data: any) => {
-                //     // fail = show the reason (setHint)
-                //     if (data.stat == 'wrongEmail') {
-                //         setHint('該電子郵件未註冊');
-                //     }
-                //     else {
-                //         setHint('密碼錯誤');
-                //     }
-                // })
+                if (1 === 1) { // change the state to false if we have server on
+                    showToast('登入成功.', '');
+                    props.navigation.push('tab', { From: 'login' });
+                    //The problem that 徐 got about login fail and stuck in the page after login might because line 44 isn't be commented, or might be some other problems.
+                }
+                else {
+                    submitLogin(logdata.email, logdata.password, (data: any) => {
+                        // success = save the logindata that response on clint device also their password
+                        const usernameLS = data.username;
+                        const headImgLS = data.headImg;
+                        const UserData = JSON.stringify({ email: logdata.email, usernameLS, headImgLS });
+                        saveData('UserData', UserData);
+                        showToast('登入成功.', '');
+                        props.navigation.push('tab', { From: 'login' });
+                    }, (data: any) => {
+                        // fail = show the reason (setHint)
+                        if (data.stat == 'wrongEmail') {
+                            setHint('該電子郵件未註冊');
+                        }
+                        else {
+                            setHint('密碼錯誤');
+                        }
+                    })
+                }
+
             }
+            setWaiting(false);
         }
         FastLogin();
     }, []);
-
+    const handleFast = () => {
+        if (fast) {
+            saveData('FastLogin', 'false');
+            setFast(false)
+        }
+        else {
+            saveData('FastLogin', 'true');
+            setFast(true)
+        }
+    }
     const handleLogin = () => {
         // Implement login logic here
         // submit email and password
-        if (true) {
+        if (passwordL && emailL) {
+        }
+        else {
+            setHint('有欄位未輸入');
+            return;
+        }
+
+        if (true) { //turn to false if server had been started
             saveCredentials(emailL, passwordL);
             const usernameLS = 'James';
             const headImgLS = '';
@@ -74,6 +111,8 @@ const LoginAssociate = (props: any) => {
             saveData('UserData', UserData);
             setEmailL('');
             setPasswordL('');
+            setHint('');
+            showToast('登入成功.', '');
             props.navigation.push('tab', { From: 'login' });//做為測試(由於伺服器未完成，待完成後取消)
         }
         else {
@@ -86,6 +125,8 @@ const LoginAssociate = (props: any) => {
                 saveData('UserData', UserData);
                 setEmailL('');
                 setPasswordL('');
+                setHint('');
+                showToast('登入成功.', '');
                 props.navigation.push('tab', { From: 'login' });
             }, (data: any) => {
                 // fail = show the reason (setHint)
@@ -103,14 +144,30 @@ const LoginAssociate = (props: any) => {
     const handleRegister = () => {
         // Implement registration logic here
         // submit email and password and username
-        if (true) {
+        if (password === passwordCheck) {
+        }
+        else {
+            setHint('兩次輸入的密碼不相符');
+            return;
+        }
+
+        if (password && email && username) {
+        }
+        else {
+            setHint('有欄位未輸入');
+            return;
+        }
+
+        if (true) { //turn to false if server had been started
             saveCredentials(email, password);
             const headImgRS = '';
             const UserData = JSON.stringify({ email, username, headImg: headImgRS });
             saveData('UserData', UserData);
             setEmail('');
             setPassword('');
+            setPasswordCheck('');
             setUsername('');
+            setHint('');
             props.navigation.push('tab', { From: 'login' });//做為測試(由於伺服器未完成，待完成後取消)
         }
         else {
@@ -123,6 +180,7 @@ const LoginAssociate = (props: any) => {
                 setEmail('');
                 setPassword('');
                 setUsername('');
+                setHint('');
                 showToast('註冊成功.', '');
                 props.navigation.push('tab', { From: 'login' });
             }, (data: any) => {
@@ -138,12 +196,15 @@ const LoginAssociate = (props: any) => {
                 }
             });
         }
+
+
     };
 
     const toggleRegistration = () => {
         setShowRegistration(!showRegistration);
         setUsername('');
         setPassword('');
+        setPasswordCheck('');
         setEmail('');
         setEmailL('');
         setPasswordL('');
@@ -151,107 +212,140 @@ const LoginAssociate = (props: any) => {
     };
 
     return (
-        (
-            <View style={styles.container}>
+        waiting ? <></> :
+            (
+                <View style={styles.container}>
 
-                {showRegistration ? (
-                    <View style={styles.form}>
-                        <Text style={styles.title}>註冊帳號</Text>
-                        <TextInput
-                            style={styles.input}
-                            placeholder="Email"
-                            placeholderTextColor="gray"
-                            value={email}
-                            onChangeText={(text) => setEmail(text)}
-                        />
-                        <TextInput
-                            style={styles.input}
-                            placeholder="Username"
-                            placeholderTextColor="gray"
-                            value={username}
-                            onChangeText={(text) => setUsername(text)}
-                        />
-                        <TextInput
-                            style={styles.input}
-                            placeholder="Password"
-                            placeholderTextColor="gray"
-                            secureTextEntry={!showPassword}
-                            value={password}
-                            onChangeText={(text) => setPassword(text)}
-                        />
-                        {
-                            hint == "" ? (<Text style={styles.hintNormal}>輸入電子郵件、帳號名稱、密碼來註冊帳號</Text>) : (<Text style={styles.hintWarning}>{hint}</Text>)
-                        }
-                        <View style={styles.row}>
-                            <Pressable onPress={toggleRegistration} style={({ pressed }) => [
-                                styles.pressable,
+                    {showRegistration ? (
+                        <View style={styles.form}>
+                            <Text style={styles.title}>註冊帳號</Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Email"
+                                placeholderTextColor="gray"
+                                value={email}
+                                onChangeText={(text) => setEmail(text)}
+                            />
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Username - Max Length 20"
+                                placeholderTextColor="gray"
+                                value={username}
+                                maxLength={20}
+                                onChangeText={(text) => setUsername(text)}
+                            />
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Password - Max Length 20"
+                                placeholderTextColor="gray"
+                                secureTextEntry={!showPassword}
+                                value={password}
+                                maxLength={20}
+                                onChangeText={(text) => setPassword(text)}
+                            />
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Enter Your Password Again"
+                                placeholderTextColor="gray"
+                                secureTextEntry={!showPassword}
+                                value={passwordCheck}
+                                maxLength={20}
+                                onChangeText={(text) => setPasswordCheck(text)}
+                            />
+
+                            {
+                                hint == "" ? (<Text style={styles.hintNormal}>輸入電子郵件、帳號名稱、密碼來註冊帳號</Text>) : (<Text style={styles.hintWarning}>{hint}</Text>)
+                            }
+
+                            <View style={styles.row}>
+                                <Pressable onPress={toggleRegistration} style={({ pressed }) => [
+                                    styles.pressable,
+                                    {
+                                        opacity: pressed ? 0.8 : 1,
+                                        borderColor: '#FFBB77'
+                                    }
+                                ]}><Text style={styles.pressableText}>改為登入</Text>
+                                </Pressable>
+                                <Pressable onPress={handleRegister} style={({ pressed }) => [
+                                    styles.pressable,
+                                    {
+                                        opacity: pressed ? 0.8 : 1,
+                                        borderColor: '#FFBB77'
+                                    }
+                                ]}><Text style={styles.pressableText}>註冊</Text>
+                                </Pressable>
+                            </View>
+
+                        </View>
+                    ) : (
+                        <View style={styles.form}>
+                            <Text style={styles.title}>登入</Text>
+
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Email"
+                                placeholderTextColor="gray"
+                                value={emailL}
+                                maxLength={20}
+                                onChangeText={(text) => setEmailL(text)}
+                            />
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Password"
+                                placeholderTextColor="gray"
+                                secureTextEntry={!showPassword}
+                                value={passwordL}
+                                maxLength={20}
+                                onChangeText={(text) => setPasswordL(text)}
+                            />
+
+                            {
+                                hint == "" ? (<Text style={styles.hintNormal}>輸入電子郵件、密碼來登入</Text>) : (<Text style={styles.hintWarning}>{hint}</Text>)
+                            }
+
+                            <View style={styles.row}>
+                                <Pressable onPress={toggleRegistration} style={({ pressed }) => [
+                                    styles.pressable,
+                                    {
+                                        opacity: pressed ? 0.8 : 1,
+                                        borderColor: '#FFBB77'
+                                    }
+                                ]}><Text style={styles.pressableText}>改為註冊</Text>
+                                </Pressable>
+                                <Pressable onPress={handleLogin} style={({ pressed }) => [
+                                    styles.pressable,
+                                    {
+                                        opacity: pressed ? 0.8 : 1,
+                                        borderColor: '#FFBB77'
+                                    }
+                                ]}><Text style={styles.pressableText}>登入</Text>
+                                </Pressable>
+                            </View>
+                            <Pressable style={styles.row} onPress={handleFast}>
                                 {
-                                    backgroundColor: pressed ? '#FFAF60' : 'orange',
-                                    borderColor: pressed ? 'orange' : '#FFAF60',
+                                    fast ? (
+
+                                        <Icon name="checkbox-outline" size={25} aria-label="Selected" />
+
+
+
+                                    ) : (
+
+                                        <Icon name="square-outline" size={25} aria-label="Unselected" />
+
+
+                                    )
                                 }
-                            ]}><Text style={styles.pressableText}>改為登入</Text>
-                            </Pressable>
-                            <Pressable onPress={handleRegister} style={({ pressed }) => [
-                                styles.pressable,
-                                {
-                                    backgroundColor: pressed ? '#FFAF60' : 'orange',
-                                    borderColor: pressed ? 'orange' : '#FFAF60',
-                                }
-                            ]}><Text style={styles.pressableText}>註冊</Text>
+                                <Text style={{ fontSize: 16 }}> 下次進入程式是否直接登入</Text>
                             </Pressable>
                         </View>
-
-                    </View>
-                ) : (
-                    <View style={styles.form}>
-                        <Text style={styles.title}>登入</Text>
-
-                        <TextInput
-                            style={styles.input}
-                            placeholder="Email"
-                            placeholderTextColor="gray"
-                            value={emailL}
-                            onChangeText={(text) => setEmailL(text)}
-                        />
-                        <TextInput
-                            style={styles.input}
-                            placeholder="Password"
-                            placeholderTextColor="gray"
-                            secureTextEntry={!showPassword}
-                            value={passwordL}
-                            onChangeText={(text) => setPasswordL(text)}
-                        />
-                        {
-                            hint == "" ? (<Text style={styles.hintNormal}>輸入電子郵件、密碼來登入</Text>) : (<Text style={styles.hintWarning}>{hint}</Text>)
-                        }
-                        <View style={styles.row}>
-                            <Pressable onPress={toggleRegistration} style={({ pressed }) => [
-                                styles.pressable,
-                                {
-                                    backgroundColor: pressed ? '#FFAF60' : 'orange',
-                                    borderColor: pressed ? 'orange' : '#FFAF60',
-                                }
-                            ]}><Text style={styles.pressableText}>改為註冊</Text>
-                            </Pressable>
-                            <Pressable onPress={handleLogin} style={({ pressed }) => [
-                                styles.pressable,
-                                {
-                                    backgroundColor: pressed ? '#FFAF60' : 'orange',
-                                    borderColor: pressed ? 'orange' : '#FFAF60',
-                                }
-                            ]}><Text style={styles.pressableText}>登入</Text>
-                            </Pressable>
-                        </View>
-
-                    </View>
-                )}
-            </View>
-        ));
+                    )}
+                </View>
+            ));
 };
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        backgroundColor: 'white',
         alignItems: 'center',
         justifyContent: 'center',
     },
@@ -259,8 +353,8 @@ const styles = StyleSheet.create({
         fontSize: 32,
         fontWeight: 'bold',
         marginBottom: 15,
-        color: '#000000',
         textAlign: 'center',
+
     },
     form: {
         width: 300,
@@ -269,23 +363,22 @@ const styles = StyleSheet.create({
         height: 45,
         margin: 12,
         padding: 5,
-        elevation:1,
-        
+        elevation: 1,
+
         borderColor: 'gray',
         color: '#000000',
-        backgroundColor:'white',
+        backgroundColor: 'white',
         fontSize: 20,
         borderRadius: 8,
 
     },
     row: {
-        paddingVertical: 10,
+        paddingTop: 10,
         flexDirection: 'row',
         justifyContent: 'center',
         alignItems: 'center',
     },
     pressable: {
-        elevation:1,
         width: 120,
         height: 45,
         padding: 5,
@@ -295,8 +388,7 @@ const styles = StyleSheet.create({
     },
     pressableText: {
         textAlign: 'center',
-        color: 'white',
-        fontWeight:'bold',
+        fontWeight: 'bold',
         fontSize: 20,
     },
     hintNormal: {

--- a/Profile/Modify/Password/index.tsx
+++ b/Profile/Modify/Password/index.tsx
@@ -59,19 +59,21 @@ const PasswordModal = ({ visible, onClose, onSave }: any) => {
                     <Text style={styles.intro}>輸入舊密碼</Text>
                     <TextInput
                         style={styles.input}
-                        placeholder="舊密碼"
+                        placeholder="舊密碼 - Max Length 20"
                         placeholderTextColor="gray"
                         secureTextEntry={true}
                         value={newPassword}
+                        maxLength={20}
                         onChangeText={setNewPassword}
                     />
                     <Text style={styles.intro}>輸入新密碼</Text>
                     <TextInput
                         style={styles.input}
-                        placeholder="新密碼"
+                        placeholder="新密碼 - Max Length 20"
                         placeholderTextColor="gray"
                         secureTextEntry={true}
                         value={oldPassword}
+                        maxLength={20}
                         onChangeText={setOldPassword}
                     />
 

--- a/Profile/Modify/Username/index.tsx
+++ b/Profile/Modify/Username/index.tsx
@@ -53,9 +53,10 @@ const UsernameModal = ({ visible, onClose, onSave, currentUsername }: any) => {
                     <Text style={styles.currentUsername}>當前帳號名稱:{currentUsername}</Text>
                     <TextInput
                         style={styles.input}
-                        placeholder="輸入新帳號"
+                        placeholder="輸入新帳號 最多20字"
                         value={newUsername}
                         onChangeText={setNewUsername}
+                        maxLength={20}
                     />
                     <View style={styles.buttonContainer}>
                         <Pressable onPress={handleClose} style={({ pressed }) => [


### PR DESCRIPTION
0.快速登入 失敗處置 要先排錯， 可能是未顯示view, 卡server, 先試試看把 navigation 跳轉拿掉 -> 這裡沒發生此狀況，可能是開伺服器時測試用的navigation pop 未註解
1..增加 登入 提示 (toast 登入成功)
2.勾選記住密碼，(以及決定是否直接登入) -> 或許也加入設定
3.可以增加一格(輸入兩次密碼) (註冊確認前，直接比對)
4.密碼，帳號長度限制 ( text input  max length ex. 20)， 同時改modify (modify 也應該增加顯示 email) 5.去除background color 符合 theme, text color 也去除
6.增加waiting state, 在進入此頁時啟用(for cover the time using useState)